### PR TITLE
Fixed RampedValue for new ControlGenerator implementation

### DIFF
--- a/Demo/iOS/TonicDemo/TonicDemo/FMDroneSynth.h
+++ b/Demo/iOS/TonicDemo/TonicDemo/FMDroneSynth.h
@@ -26,7 +26,7 @@ class FMDroneSynth : public Synth {
 public:
   FMDroneSynth(){
     outputGen = SineWave().freq(
-      RampedValue().setValue( registerMessage("baseFreq", 200) )
+       RampedValue().target( registerMessage("baseFreq", 200) ).lengthMs(100)
     );
   }
   

--- a/Demo/iOS/TonicDemo/TonicDemo/SineAMSynth.h
+++ b/Demo/iOS/TonicDemo/TonicDemo/SineAMSynth.h
@@ -25,8 +25,9 @@ public:
 
   SineAMSynth() : carrierAmt(1.0f) {
     
-    carrierFreq.defValue(400).defLenMs(2000);
-    modFreq.defValue(10);
+    // TODO: do this by registering messages
+    carrierFreq.value(400).lengthMs(2000);
+    modFreq.value(10).lengthMs(200);
     
     carrier.freq(carrierFreq);
     modulator.freq(modFreq);
@@ -34,13 +35,13 @@ public:
     outputGen =
     (
       ( modulator + carrierAmt ) * carrier
-    ) * 0.1f;
+    ) * 0.5f;
     
   };
   
   inline void setCarrierAmt(TonicFloat newCarrierAmt) { carrierAmt = clamp(newCarrierAmt, 0.0f, 1.0f); };
-  inline void setCarrierFreq(TonicFloat nCarFreq) { carrierFreq.setTarget(nCarFreq); };
-  inline void setModFreq(TonicFloat nModFreq) { modFreq.setTarget(nModFreq); };
+  inline void setCarrierFreq(TonicFloat nCarFreq) { carrierFreq.target(nCarFreq); };
+  inline void setModFreq(TonicFloat nModFreq) { modFreq.target(nModFreq); };
   
 private:
   

--- a/Demo/iOS/TonicDemo/TonicDemo/SineSumSynth.h
+++ b/Demo/iOS/TonicDemo/TonicDemo/SineSumSynth.h
@@ -28,13 +28,13 @@ public:
   SineSumSynth () {
     
     for (int s=0; s<NUM_SINES; s++){
-      sineMixer.in(sines[s].freq(sineFreqs[s].defValue(440).defLenMs(100)));
+      sineMixer.in(sines[s].freq(sineFreqs[s].value(440).lengthMs(100)));
     }
     
     outputGen =
     (
       sineMixer
-    ) * (1.0f/NUM_SINES) * 0.25;
+    ) * (1.0f/NUM_SINES) * 0.5f;
 
     
   }
@@ -43,7 +43,7 @@ public:
     for (int i=0; i<NUM_SINES; i++){
       // spread up to an octave apart
       TonicFloat freq = 440.0f * powf(2, spread*(i - (NUM_SINES/2)));
-      sineFreqs[i].setTarget(freq);
+      sineFreqs[i].target(freq);
     }
   }
   

--- a/Tonic/Core/ControlValue.cpp
+++ b/Tonic/Core/ControlValue.cpp
@@ -24,6 +24,9 @@ namespace Tonic {
     }
     
     TonicFloat ControlValue_::getValue(){
+      // TODO: Until we figure out a better way to manage multiple instances of
+      // ControlGenerators, this should also reset hasChanged()
+      mHasChanged = false;
       return mValue;
     }
     

--- a/Tonic/Core/ControlValue.h
+++ b/Tonic/Core/ControlValue.h
@@ -34,10 +34,16 @@ namespace Tonic {
   
   class ControlValue : public TemplatedControlGenerator<Tonic_::ControlValue_>{
     public:
-      ControlValue & setValue(
-        float value){gen()->setValue(value);
+      ControlValue & setValue(float value)
+      {
+        gen()->setValue(value);
         return *this;
       }
+    
+    ControlValue & setHasChanged(bool flagVal){
+      gen()->setHasChanged(flagVal);
+      return *this;
+    }
   };
 
 }

--- a/Tonic/Core/Synth.cpp
+++ b/Tonic/Core/Synth.cpp
@@ -31,7 +31,6 @@ namespace Tonic {
 
   inline void Synth::tick( TonicFrames& frames ){
     outputGen.tick(frames);
-    
   };
 
   ControlValue  Synth::registerMessage(string name, float value){

--- a/Tonic/Utils/RampedValue.cpp
+++ b/Tonic/Utils/RampedValue.cpp
@@ -13,14 +13,16 @@ namespace Tonic { namespace Tonic_{
   RampedValue_::RampedValue_() :
     finished_(true),
     count_(0),
-    defLen_(2205),
     len_(2205),
     target_(0),
     last_(0),
-    inc_(0),
-    valueGen(ControlValue()) // shouldn't need to set this. See https://github.com/morganpackard/Tonic/issues/6
+    inc_(0)
   {
-    
+    // shouldn't need to set this. See https://github.com/morganpackard/Tonic/issues/6
+    // still, good to give default values to the relevant generators
+    setTargetGen(ControlValue().setValue(0));
+    setLengthMsGen(ControlValue().setValue(0.5f));
+    setValueGen(ControlValue().setValue(0));
   }
   
   RampedValue_::~RampedValue_(){
@@ -29,38 +31,41 @@ namespace Tonic { namespace Tonic_{
 
 } // Namespace Tonic_
   
-  RampedValue & RampedValue::defLenMs(TonicFloat defLenMs){
-    gen()->setDefaultLength( defLenMs*Tonic::sampleRate()/1000.0f );
-    return  *this;
-  }
   
-  RampedValue & RampedValue::defValue(TonicFloat defValue){
-    gen()->setValue(defValue);
-    return *this;
-  }  
-  
-  RampedValue & RampedValue::setTarget( ControlGenerator target ){
+  //! Set target value
+  RampedValue & RampedValue::target( TonicFloat target ){
+    ControlValue v = ControlValue().setValue(target);
+    gen()->setTargetGen(v);
     return *this;
   }
   
-  RampedValue & RampedValue::setValue( TonicFloat value){
-    setValue(ControlValue().setValue(value));
+  RampedValue & RampedValue::target( ControlGenerator target ){
+    gen()->setTargetGen(target);
     return *this;
   }
   
-  RampedValue & RampedValue::setValue( ControlGenerator value){
-    Tonic_::RampedValue_* localGen = gen();
-    localGen->lockMutex();
-    localGen->setValue(value);
-    localGen->unlockMutex();
+  //! Set length before reaching target value, in ms
+  RampedValue & RampedValue::lengthMs( TonicFloat lengthMs ){
+    ControlValue v = ControlValue().setValue(lengthMs);
+    gen()->setLengthMsGen(v);
     return *this;
   }
   
-  RampedValue & RampedValue::setTarget(TonicFloat target, TonicFloat lenMs){
-    unsigned long length = lenMs > 0 ? lenMs*Tonic::sampleRate()/1000.0f : 0;
-    gen()->setTarget(target, length);
+  RampedValue & RampedValue::lengthMs( ControlGenerator lengthMs ){
+    gen()->setLengthMsGen(lengthMs);
     return *this;
   }
-
+  
+  //! Go to value immediately
+  RampedValue & RampedValue::value( TonicFloat value){
+    ControlValue v = ControlValue().setValue(value);
+    gen()->setValueGen(v);
+    return *this;
+  }
+  
+  RampedValue & RampedValue::value( ControlGenerator value){
+    gen()->setValueGen(value);
+    return *this;
+  }
   
 } // Namespace Tonic


### PR DESCRIPTION
RampedValue was incomplete for the new ControlGenerator protocol. It's been updated.

Also needed to reset hasChanged() on ControlValues. We'll need to iron out a good way to manage this, especially if values can be used for multiple parameters.
