### PR TITLE
Refactor wet/dry logic into a new subclass of Effect

### DIFF
--- a/src/Tonic/BasicDelay.h
+++ b/src/Tonic/BasicDelay.h
@@ -19,7 +19,7 @@ namespace Tonic {
   
   namespace Tonic_ {
 
-    class BasicDelay_ : public Effect_{
+    class BasicDelay_ : public WetDryEffect_{
       
     protected:
       
@@ -82,7 +82,7 @@ namespace Tonic {
   }
   
   
-  class BasicDelay : public TemplatedEffect<BasicDelay, Tonic_::BasicDelay_>{
+  class BasicDelay : public TemplatedWetDryEffect<BasicDelay, Tonic_::BasicDelay_>{
     
   public:
     //! Allocating only with time argument will default max delay time to 1.5 * delayTime

--- a/src/Tonic/CombFilter.cpp
+++ b/src/Tonic/CombFilter.cpp
@@ -11,7 +11,6 @@
 namespace Tonic { namespace Tonic_{
   
   CombFilter_::CombFilter_(){
-    setIsAlwaysWet(true);
     delayTimeFrames_.resize(kSynthesisBlockSize, 1, 0);
   }
   

--- a/src/Tonic/CompressorLimiter.cpp
+++ b/src/Tonic/CompressorLimiter.cpp
@@ -11,7 +11,6 @@
 namespace Tonic { namespace Tonic_{
   
   Compressor_::Compressor_() : isLimiter_(false), gainEnvValue_(1.f), ampEnvValue_(0) {
-    setIsAlwaysWet(true);
     ampInputFrames_.resize(kSynthesisBlockSize, 1, 0);
     lookaheadDelayLine_.initialize(0.01, 2);
     lookaheadDelayLine_.setInterpolates(false); // No real need to interpolate here for lookahead

--- a/src/Tonic/Effect.cpp
+++ b/src/Tonic/Effect.cpp
@@ -11,16 +11,25 @@
 
 #include "Effect.h"
 
-namespace Tonic {
-  namespace Tonic_ {
+namespace Tonic
+{
+  
+  namespace Tonic_
+  {
    
-    Effect_::Effect_() : isAlwaysWet_(false), isStereoInput_(false){
+    Effect_::Effect_() : isStereoInput_(false)
+    {
       dryFrames_.resize(kSynthesisBlockSize, 1, 0);
-      mixWorkspace_.resize(kSynthesisBlockSize, 1, 0);
       bypassGen_ = ControlValue(0);
+    }
+    
+    WetDryEffect_::WetDryEffect_()
+    {
+      mixWorkspace_.resize(kSynthesisBlockSize, 1, 0);
       dryLevelGen_ = FixedValue(0.5);
       wetLevelGen_ = FixedValue(0.5);
     }
     
   }
+  
 }

--- a/src/Tonic/Effect.h
+++ b/src/Tonic/Effect.h
@@ -12,7 +12,6 @@
 #ifndef __Tonic__Effect__
 #define __Tonic__Effect__
 
-#include <iostream>
 #include "Generator.h"
 
 namespace Tonic {
@@ -20,54 +19,40 @@ namespace Tonic {
   namespace Tonic_ {
     
     class Effect_ : public Generator_{
-      
-    private:
-      
-      ControlGenerator bypassGen_;
-      Generator  dryLevelGen_;
-      Generator  wetLevelGen_;
-      TonicFrames mixWorkspace_;
-      bool isAlwaysWet_;
-      bool isStereoInput_;
-      
-    protected:
-      
-      Generator input_;
-      TonicFrames dryFrames_;
-      
-    public:
-      
-      Effect_();
-            
-      void setBypassCtrlGen( ControlGenerator gen ){ bypassGen_ = gen; };
-      void setDryLevelGen( Generator gen ){ dryLevelGen_ = gen; };
-      void setWetLevelGen( Generator gen ){ wetLevelGen_ = gen; };
 
-      virtual void setInput( Generator input ) { input_ = input; };
-      
-      //! Set to true to disable dry/wet (always fully wet)
-      /*!
-          For effects that will always be fully-wet (filters, compressor, etc) setting this flag to true
-          will bypass applying dry/wet level inputs as a minor CPU usage optimization
-       */
-      void setIsAlwaysWet( bool isAlwaysWet ) { isAlwaysWet_ = isAlwaysWet; };
-      
-      //! set stereo/mono - changes number of channels in dryFrames_
-      /*!
-          subclasses should call in constructor to determine input channel layout
-      */
-      virtual void setIsStereoInput( bool stereo );
-      bool isStereoInput(){ return isStereoInput_; };
-      
-      // --- Tick methods ---
-      
-      virtual void tick(TonicFrames &frames, const SynthesisContext_ &context );
-      
-      //! Apply effect directly to passed in frames (output in-place)
-      /*!
-          DO NOT mix calls to tick() with calls to tickThrough(). Result is undefined.
-      */
-      virtual void tickThrough( TonicFrames & inFrames, TonicFrames & outFrames, const SynthesisContext_ & context );
+      protected:
+        
+        Generator input_;
+        TonicFrames dryFrames_;
+        
+        ControlGenerator bypassGen_;
+        bool isStereoInput_;
+        
+      public:
+        
+        Effect_();
+              
+        void setBypassCtrlGen( ControlGenerator gen ){ bypassGen_ = gen; };
+
+        virtual void setInput( Generator input ) { input_ = input; };
+        
+        //! set stereo/mono - changes number of channels in dryFrames_
+        /*!
+            subclasses should call in constructor to determine input channel layout
+        */
+        virtual void setIsStereoInput( bool stereo );
+        
+        bool isStereoInput() { return isStereoInput_; };
+
+        // --- Tick methods ---
+        
+        virtual void tick(TonicFrames &frames, const SynthesisContext_ &context );
+        
+        //! Apply effect directly to passed in frames (output in-place)
+        /*!
+            DO NOT mix calls to tick() with calls to tickThrough().
+        */
+        virtual void tickThrough( TonicFrames & inFrames, TonicFrames & outFrames, const SynthesisContext_ & context );
 
     };
     
@@ -98,16 +83,7 @@ namespace Tonic {
         if (bypass){
           outputFrames_.copy(dryFrames_);
         }
-        else if (!isAlwaysWet_){
-          // do not apply dry/wet levels if always wet flag is set
-          // offers minor CPU usage optimization
-          wetLevelGen_.tick(mixWorkspace_, context);
-          outputFrames_ *= mixWorkspace_;
-          dryLevelGen_.tick(mixWorkspace_, context);
-          dryFrames_ *= mixWorkspace_;
-          outputFrames_ += dryFrames_;
-        }
-                
+        
         lastFrameIndex_ = context.elapsedFrames;
       }
       
@@ -135,15 +111,6 @@ namespace Tonic {
           outFrames.copy(dryFrames_);
         }
         else{
-          
-          if (!isAlwaysWet_){
-            wetLevelGen_.tick(mixWorkspace_, context);
-            outputFrames_ *= mixWorkspace_;
-            dryLevelGen_.tick(mixWorkspace_, context);
-            dryFrames_ *= mixWorkspace_;
-            outputFrames_ += dryFrames_;
-          }
-          
           outFrames.copy(outputFrames_);
         }
       
@@ -151,35 +118,31 @@ namespace Tonic {
   }
   
   template<class EffectType, class EffectType_>
-  class TemplatedEffect : public TemplatedGenerator<EffectType_>{
+  class TemplatedEffect : public TemplatedGenerator<EffectType_>
+  {
     
-  public:
-        
-    // This cast is not safe - up to implementation to ensure that templated EffectType_ is actually an Effect_ subclass
-    virtual EffectType & input( Generator input ){
-      this->gen()->setInput( input );
-      return static_cast<EffectType&>(*this);
-    }
-    
-    void tickThrough( TonicFrames & inFrames, const Tonic_::SynthesisContext_ & context){ // ticks in-place
-      this->gen()->tickThrough(inFrames, inFrames, context);
-    }
-    
-    void tickThrough(TonicFrames & inFrames, TonicFrames & outFrames, const Tonic_::SynthesisContext_ & context){
-      this->gen()->tickThrough(inFrames, outFrames, context);
-    }
-    
-    void setIsStereoInput( bool isStereoInput ){
-      this->gen()->setIsStereoInput(isStereoInput);
-    }
-    
-    createControlGeneratorSetters(EffectType, bypass, setBypassCtrlGen);
-    
-    // Defaults to 1.0
-    createGeneratorSetters(EffectType, wetLevel, setWetLevelGen);
-    
-    // Defaults to 0.0 (full wet)
-    createGeneratorSetters(EffectType, dryLevel, setDryLevelGen);
+    public:
+          
+      // This cast is not safe - up to implementation to ensure that templated EffectType_ is actually an Effect_ subclass
+      virtual EffectType & input( Generator input ){
+        this->gen()->setInput( input );
+        return static_cast<EffectType&>(*this);
+      }
+      
+      void tickThrough( TonicFrames & inFrames, const Tonic_::SynthesisContext_ & context){ // ticks in-place
+        this->gen()->tickThrough(inFrames, inFrames, context);
+      }
+      
+      void tickThrough(TonicFrames & inFrames, TonicFrames & outFrames, const Tonic_::SynthesisContext_ & context){
+        this->gen()->tickThrough(inFrames, outFrames, context);
+      }
+      
+      void setIsStereoInput( bool isStereoInput ){
+        this->gen()->setIsStereoInput(isStereoInput);
+      }
+      
+      createControlGeneratorSetters(EffectType, bypass, setBypassCtrlGen);
+
   };
   
   // signal flow operator - sets lhs as input to rhs
@@ -188,6 +151,147 @@ namespace Tonic {
     return rhs.input( lhs );
   }
 
+  
+  // ------------------------------------
+  //        Wet/Dry mix effects
+  // ------------------------------------
+  
+  namespace Tonic_
+  {
+    
+    // WetDryEffect_ extends the basic functionality of Effect_ but also adds a wet/dry mix to the basic tick() cycle
+    class WetDryEffect_ : public Effect_
+    {
+      protected:
+      
+        Generator  dryLevelGen_;
+        Generator  wetLevelGen_;
+        TonicFrames mixWorkspace_;
+      
+      public:
+      
+        WetDryEffect_();
+      
+        void setDryLevelGen( Generator gen ){ dryLevelGen_ = gen; };
+        void setWetLevelGen( Generator gen ){ wetLevelGen_ = gen; };
+      
+      // --- Tick methods ---
+      
+      virtual void tick(TonicFrames &frames, const SynthesisContext_ &context );
+      
+      //! Apply effect directly to passed in frames (output in-place)
+      /*!
+          DO NOT mix calls to tick() with calls to tickThrough().
+       */
+      virtual void tickThrough( TonicFrames & inFrames, TonicFrames & outFrames, const SynthesisContext_ & context );
+
+    };
+    
+    // Overridden tick - pre-ticks input to fill dryFrames_.
+    // subclasses don't need to tick input - dryFrames_ contains "dry" input by the time
+    // computeSynthesisBlock() is called
+    inline void WetDryEffect_::tick(TonicFrames &frames, const SynthesisContext_ &context ){
+      
+      // check context to see if we need new frames
+      if (context.elapsedFrames == 0 || lastFrameIndex_ != context.elapsedFrames){
+        
+        // get dry input frames
+        input_.tick(dryFrames_, context);
+        
+        computeSynthesisBlock(context);
+        
+        // bypass processing - still need to compute block so all generators stay in sync
+        bool bypass = bypassGen_.tick(context).value != 0.f;
+        if (bypass){
+          outputFrames_.copy(dryFrames_);
+        }
+        else{
+          // do not apply dry/wet levels if always wet flag is set
+          // offers minor CPU usage optimization
+          wetLevelGen_.tick(mixWorkspace_, context);
+          outputFrames_ *= mixWorkspace_;
+          dryLevelGen_.tick(mixWorkspace_, context);
+          dryFrames_ *= mixWorkspace_;
+          outputFrames_ += dryFrames_;
+        }
+        
+        lastFrameIndex_ = context.elapsedFrames;
+      }
+      
+      // copy synthesis block to frames passed in
+      frames.copy(outputFrames_);
+      
+#ifdef TONIC_DEBUG
+      if(!isfinite(frames(0,0))){
+        Tonic::error("Effect_::tick NaN or inf detected.");
+      }
+#endif
+      
+    }
+    
+    inline void WetDryEffect_::tickThrough(TonicFrames & inFrames, TonicFrames & outFrames, const SynthesisContext_ & context){
+      
+      // Do not check context here, assume each call should produce new output.
+      
+      dryFrames_.copy(inFrames);
+      computeSynthesisBlock(context);
+      
+      // bypass processing - still need to compute block so all generators stay in sync
+      bool bypass = bypassGen_.tick(context).value != 0.f;
+      if (bypass){
+        outFrames.copy(dryFrames_);
+      }
+      else {
+        wetLevelGen_.tick(mixWorkspace_, context);
+        outputFrames_ *= mixWorkspace_;
+        dryLevelGen_.tick(mixWorkspace_, context);
+        dryFrames_ *= mixWorkspace_;
+        outputFrames_ += dryFrames_;
+        outFrames.copy(outputFrames_);
+      }
+            
+    }
+    
+  }
+  
+  template<class EffectType, class EffectType_>
+  class TemplatedWetDryEffect : public TemplatedGenerator<EffectType_>
+  {
+      
+    public:
+      
+      // This cast is not safe - up to implementation to ensure that templated EffectType_ is actually an Effect_ subclass
+      virtual EffectType & input( Generator input ){
+        this->gen()->setInput( input );
+        return static_cast<EffectType&>(*this);
+      }
+      
+      void tickThrough( TonicFrames & inFrames, const Tonic_::SynthesisContext_ & context){ // ticks in-place
+        this->gen()->tickThrough(inFrames, inFrames, context);
+      }
+      
+      void tickThrough(TonicFrames & inFrames, TonicFrames & outFrames, const Tonic_::SynthesisContext_ & context){
+        this->gen()->tickThrough(inFrames, outFrames, context);
+      }
+      
+      void setIsStereoInput( bool isStereoInput ){
+        this->gen()->setIsStereoInput(isStereoInput);
+      }
+      
+      createControlGeneratorSetters(EffectType, bypass, setBypassCtrlGen);
+      
+      // Defaults to 1.0
+      createGeneratorSetters(EffectType, wetLevel, setWetLevelGen);
+
+      // Defaults to 0.0 (full wet)
+      createGeneratorSetters(EffectType, dryLevel, setDryLevelGen);
+  };
+  
+  // signal flow operator - sets lhs as input to rhs
+  template<class EffectType, class EffectType_>
+  static EffectType operator>>(Generator lhs, TemplatedWetDryEffect<EffectType, EffectType_> rhs){
+    return rhs.input( lhs );
+  }
 }
 
 #endif /* defined(__Tonic__Effect__) */

--- a/src/Tonic/Filters.cpp
+++ b/src/Tonic/Filters.cpp
@@ -20,7 +20,6 @@ namespace Tonic { namespace Tonic_{
     bypass_(ControlValue(0)),
     bNormalizeGain_(true)
   {
-    setIsAlwaysWet(true);
     workspace_.resize(kSynthesisBlockSize, 1, 0);
   }
   

--- a/src/Tonic/MonoToStereoPanner.cpp
+++ b/src/Tonic/MonoToStereoPanner.cpp
@@ -13,7 +13,6 @@ namespace Tonic{
   namespace Tonic_{
   
     MonoToStereoPanner_::MonoToStereoPanner_(){
-      setIsAlwaysWet(true);
       setIsStereoOutput(true);
       panFrames.resize(kSynthesisBlockSize, 1);
       setPan(ControlValue(0));

--- a/src/Tonic/Reverb.h
+++ b/src/Tonic/Reverb.h
@@ -88,7 +88,7 @@ namespace Tonic {
         - More deterministic early reflection time scattering.
      */
     
-    class Reverb_ : public Effect_
+    class Reverb_ : public WetDryEffect_
     {
       protected:
       
@@ -225,7 +225,7 @@ namespace Tonic {
         
   }
   
-  class Reverb : public TemplatedEffect<Reverb, Tonic_::Reverb_>
+  class Reverb : public TemplatedWetDryEffect<Reverb, Tonic_::Reverb_>
   {
 
     public:

--- a/src/Tonic/StereoDelay.h
+++ b/src/Tonic/StereoDelay.h
@@ -19,7 +19,7 @@ namespace Tonic {
   
   namespace Tonic_ {
 
-    class StereoDelay_ : public Effect_{
+    class StereoDelay_ : public WetDryEffect_{
       
     protected:
     
@@ -91,7 +91,7 @@ namespace Tonic {
     
   }
   
-  class StereoDelay : public TemplatedEffect<StereoDelay, Tonic_::StereoDelay_>{
+  class StereoDelay : public TemplatedWetDryEffect<StereoDelay, Tonic_::StereoDelay_>{
     
   public:
   


### PR DESCRIPTION
Serves two purposes:
- Effects that don't need wet/dry levels (filters for example) are always more efficient now
  - No need to set "isAlwaysWet", which was a bit awkward to do
- Effects without wet/dry levels shouldn't have setters to change wet/dry levels
