### PR TITLE
fixed ADSR volume overrun

### DIFF
--- a/src/Tonic/ADSR.h
+++ b/src/Tonic/ADSR.h
@@ -139,7 +139,7 @@ namespace Tonic {
             
             // how many samples remain in current segment
             unsigned long remainder = (segCounter > segLength) ? 0 : segLength - segCounter;
-            if (remainder < samplesRemaining){
+            if (remainder <= samplesRemaining){
               
               // fill up part of the ramp then switch segment
 


### PR DESCRIPTION
When playing with different sample rates I experienced massive sound distortion.
Turned out theres a critical issue when an ADSR segment ends on a kSynthesisBlock boundary - in this case remainder becomes 0 which in corrupts lastValue: 

lastValue += increment*(remainder-1);
