### PR TITLE
fix: first beat triggers with a delay when Tonic starts

### DIFF
--- a/src/Tonic/ControlMetro.h
+++ b/src/Tonic/ControlMetro.h
@@ -41,7 +41,7 @@ namespace Tonic {
       
       double sPerBeat = 60.0/max(0.001,bpm_.tick(context).value);
       double delta = context.elapsedTime - lastClickTime_;
-      if (delta >= 2*sPerBeat || delta < 0){
+      if (delta >= 2*sPerBeat || delta < 0 || lastClickTime_==0.0){
         // account for bpm interval outrunning tick interval or timer wrap-around
         lastClickTime_ = context.elapsedTime;
         output_.triggered = true;


### PR DESCRIPTION
 When Tonic has just started and context.elapsedTime < sPerBeat in ControlMetro, CM will trigger first not right away but with a sPerBeat-context.elapsedTime delay.
